### PR TITLE
Support setting username of username and password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 RUN mkdir /build
 ADD . /build/
 WORKDIR /build

--- a/charts/azdo-proxy/Chart.yaml
+++ b/charts/azdo-proxy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: azdo-proxy
 description: A Helm chart for azdo-proxy
 type: application
-version: v0.3.5
-appVersion: v0.3.5
+version: v0.3.6
+appVersion: v0.3.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xenitab/azdo-proxy
 
-go 1.14
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.2.0


### PR DESCRIPTION
Sometimes when using basic auth only the username will be set
while at other times botht the username and password is set.
The proxy should use the username as the token only when
the password component is not set. Otherwise it should
use the password to authenticate.

Update to Golang 1.16